### PR TITLE
Performance Fix: avoid unnecessary DB queries

### DIFF
--- a/src/App/Traits/LaravelCheckBlockedTrait.php
+++ b/src/App/Traits/LaravelCheckBlockedTrait.php
@@ -136,11 +136,15 @@ trait LaravelCheckBlockedTrait
      */
     private static function checkedBlockedList($checkAgainst, $blocked)
     {
-        $blockedItems = BlockedItem::all();
+        static $blockedItems = null;
+        if ($blockedItems === null) {
+            $blockedItems = BlockedItem::all();
+        }
 
-        foreach ($blockedItems as $blockedItems) {
-            if ($blockedItems->value == $checkAgainst) {
+        foreach ($blockedItems as $blockedItem) {
+            if ($blockedItem->value == $checkAgainst) {
                 $blocked = true;
+                break;
             }
         }
 


### PR DESCRIPTION
This patch 

1) Caches the results of BlockedItem::all() in a local static variable in order to avoid multiple DB calls (as used in laravel-auth). 
2) Exits the blocked-check after the first match, thus potentially reducing the number of items processed in this loop.