### PR TITLE
Fix eklundkristoffer/seedster version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0|^8.1|^8.2",
-        "eklundkristoffer/seedster": "^7.0",
+        "php": "^7.3|^8.0",
+        "eklundkristoffer/seedster": "^7.0|^8.0|^9.0",
         "laravelcollective/html": "^6.4"
     },
     "autoload": {


### PR DESCRIPTION
This package require "eklundkristoffer/seedster": "^7.0",
and jeremykenedy/laravel-roles require "eklundkristoffer/seedster": "^8.0|^9.0",

there is no differences between theses version.
https://github.com/eklundkristoffer/seedster/compare/6.0...9.0

let's put them all

also removing redundant php version